### PR TITLE
Build fixes for GCC 15.3 and PUC Lua 5.1.5

### DIFF
--- a/crawl-ref/source/cluautil.cc
+++ b/crawl-ref/source/cluautil.cc
@@ -52,7 +52,7 @@ void luaopen_setmeta(lua_State *ls,
     luaL_newmetatable(ls, meta);
     lua_setglobal(ls, global);
 
-    luaL_openlib(ls, global, lua_lib, 0);
+    luaL_register(ls, global, lua_lib);
 
     // Do <global>.__index = <global>
     lua_pushstring(ls, "__index");
@@ -77,8 +77,9 @@ void clua_register_metatable(lua_State *ls, const char *tn,
         lua_settable(ls, -3);
     }
 
-    if (lr)
-        luaL_openlib(ls, nullptr, lr, 0);
+    if (lr) {
+        luaL_register(ls, NULL, lr);
+    }
 }
 
 int clua_pushcxxstring(lua_State *ls, const string &s)

--- a/crawl-ref/source/coord-circle.cc
+++ b/crawl-ref/source/coord-circle.cc
@@ -27,7 +27,7 @@ rectangle_iterator rect_def::iter() const
 }
 
 circle_def::circle_def()
-    : global_los_radius(true), check_bounds(false), origin(coord_def(0,0))
+    : global_los_radius(true), check_bounds(false), origin(coord_def(0,0)), radius(0)
 {
     // Set up bounding box and shape.
     init(LOS_RADIUS, C_SQUARE);
@@ -43,14 +43,14 @@ circle_def::circle_def(const coord_def& origin_, const circle_def& bds)
 }
 
 circle_def::circle_def(int param, circle_type ctype)
-    : global_los_radius(false), check_bounds(false), origin(coord_def(0,0))
+    : global_los_radius(false), check_bounds(false), origin(coord_def(0,0)), radius(0)
 {
     init(param, ctype);
 }
 
 circle_def::circle_def(const coord_def &origin_, int param,
                        circle_type ctype)
-    : global_los_radius(false), check_bounds(true), origin(origin_)
+    : global_los_radius(false), check_bounds(true), origin(origin_), radius(0)
 {
     init(param, ctype);
 }

--- a/crawl-ref/source/dbg-asrt.cc
+++ b/crawl-ref/source/dbg-asrt.cc
@@ -187,7 +187,7 @@ static void _dump_player(FILE *file)
     {
         fprintf(file, "Delayed (%u):\n",
                 (unsigned int)you.delay_queue.size());
-        for (const auto delay : you.delay_queue)
+        for (const auto &delay : you.delay_queue)
         {
             fprintf(file, "    type:     %s", delay->name());
             fprintf(file, "\n");

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -314,7 +314,7 @@ bool is_being_drained(const item_def &item)
 
 bool is_being_butchered(const item_def &item, bool just_first)
 {
-    for (const auto delay : you.delay_queue)
+    for (const auto &delay : you.delay_queue)
     {
         if (delay->is_being_used(&item, OPER_BUTCHER))
             return true;
@@ -350,7 +350,7 @@ bool player_stair_delay()
  */
 bool already_learning_spell(int spell)
 {
-    for (const auto delay : you.delay_queue)
+    for (const auto &delay : you.delay_queue)
     {
         auto mem = dynamic_cast<MemoriseDelay*>(delay.get());
         if (!mem)

--- a/crawl-ref/source/dlua.cc
+++ b/crawl-ref/source/dlua.cc
@@ -294,9 +294,9 @@ void init_dungeon_lua()
     dluaopen_wiz(dlua);
     #endif
 
-    luaL_openlib(dlua, "feat", feat_dlib, 0);
-    luaL_openlib(dlua, "debug", debug_dlib, 0);
-    luaL_openlib(dlua, "los", los_dlib, 0);
+    luaL_register(dlua, "feat", feat_dlib);
+    luaL_register(dlua, "debug", debug_dlib);
+    luaL_register(dlua, "los", los_dlib);
 
     dlua.execfile("dlua/dungeon.lua", true, true);
     dlua.execfile("dlua/luamark.lua", true, true);

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5308,7 +5308,7 @@ static void _choose_arcana_mutations()
         = you.props[ARCANA_SAC_KEY].get_vector();
     ASSERT(current_arcane_sacrifices.empty());
 
-    for (const vector<mutation_type> arcane_sacrifice_list :
+    for (const vector<mutation_type> &arcane_sacrifice_list :
                                     _arcane_sacrifice_lists)
     {
         const mutation_type sacrifice =
@@ -5328,7 +5328,7 @@ static void _choose_arcana_mutations()
  */
 static bool _player_sacrificed_arcana()
 {
-    for (const vector<mutation_type> arcane_sacrifice_list :
+    for (const vector<mutation_type> &arcane_sacrifice_list :
                                     _arcane_sacrifice_lists)
     {
         for (mutation_type sacrifice : arcane_sacrifice_list)

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1520,7 +1520,7 @@ string find_crawlrc()
     // rc_dir_names list.
     for (const string &rc_dir : SysEnv.rcdirs)
     {
-        for (const string &rc_fn : rc_dir_filenames)
+        for (const char *rc_fn : rc_dir_filenames)
         {
             const string rc(catpath(rc_dir, rc_fn));
             if (file_exists(rc))

--- a/crawl-ref/source/json.cc
+++ b/crawl-ref/source/json.cc
@@ -413,7 +413,7 @@ char *json_encode(const JsonNode *node)
 
 char *json_encode_string(const char *str)
 {
-    SB sb;
+    SB sb = {};
     sb_init(&sb);
 
     emit_string(&sb, str);
@@ -423,7 +423,7 @@ char *json_encode_string(const char *str)
 
 char *json_stringify(const JsonNode *node, const char *space)
 {
-    SB sb;
+    SB sb = {};
     sb_init(&sb);
 
     if (space != nullptr)
@@ -844,7 +844,7 @@ failure:
 bool parse_string(const char **sp, char **out)
 {
     const char *s = *sp;
-    SB sb;
+    SB sb = {};
     char throwaway_buffer[4];
         /* enough space for a UTF-8 character */
     char *b;

--- a/crawl-ref/source/kills.cc
+++ b/crawl-ref/source/kills.cc
@@ -989,7 +989,7 @@ static const struct luaL_reg kill_lib[] =
 
 void cluaopen_kills(lua_State *ls)
 {
-    luaL_openlib(ls, "kills", kill_lib, 0);
+    luaL_register(ls, "kills", kill_lib);
 }
 
 #ifdef CLUA_BINDINGS

--- a/crawl-ref/source/l-colour.cc
+++ b/crawl-ref/source/l-colour.cc
@@ -110,5 +110,5 @@ static const struct luaL_reg colour_lib[] =
 
 void dluaopen_colour(lua_State *ls)
 {
-    luaL_openlib(ls, "colour", colour_lib, 0);
+    luaL_register(ls, "colour", colour_lib);
 }

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -1493,7 +1493,7 @@ void cluaopen_crawl(lua_State *ls)
     clua_register_metatable(ls, MESSF_METATABLE, crawl_messf_ops,
                             lua_object_gc<message_filter>);
 
-    luaL_openlib(ls, "crawl", crawl_clib, 0);
+    luaL_register(ls, "crawl", crawl_clib);
 }
 
 //
@@ -1733,5 +1733,5 @@ static const struct luaL_reg crawl_dlib[] =
 
 void dluaopen_crawl(lua_State *ls)
 {
-    luaL_openlib(ls, "crawl", crawl_dlib, 0);
+    luaL_register(ls, "crawl", crawl_dlib);
 }

--- a/crawl-ref/source/l-dgn.cc
+++ b/crawl-ref/source/l-dgn.cc
@@ -1927,13 +1927,13 @@ void dluaopen_dgn(lua_State *ls)
 {
     _dgn_register_metatables(ls);
 
-    luaL_openlib(ls, "dgn", dgn_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_build_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_event_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_grid_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_item_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_level_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_mons_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_subvault_dlib, 0);
-    luaL_openlib(ls, "dgn", dgn_tile_dlib, 0);
+    luaL_register(ls, "dgn", dgn_dlib);
+    luaL_register(ls, "dgn", dgn_build_dlib);
+    luaL_register(ls, "dgn", dgn_event_dlib);
+    luaL_register(ls, "dgn", dgn_grid_dlib);
+    luaL_register(ls, "dgn", dgn_item_dlib);
+    luaL_register(ls, "dgn", dgn_level_dlib);
+    luaL_register(ls, "dgn", dgn_mons_dlib);
+    luaL_register(ls, "dgn", dgn_subvault_dlib);
+    luaL_register(ls, "dgn", dgn_tile_dlib);
 }

--- a/crawl-ref/source/l-file.cc
+++ b/crawl-ref/source/l-file.cc
@@ -22,7 +22,7 @@ static const struct luaL_reg file_clib[] =
 
 void cluaopen_file(lua_State *ls)
 {
-    luaL_openlib(ls, "file", file_clib, 0);
+    luaL_register(ls, "file", file_clib);
 }
 
 //
@@ -218,5 +218,5 @@ static const struct luaL_reg file_dlib[] =
 
 void dluaopen_file(lua_State *ls)
 {
-    luaL_openlib(ls, "file", file_dlib, 0);
+    luaL_register(ls, "file", file_dlib);
 }

--- a/crawl-ref/source/l-food.cc
+++ b/crawl-ref/source/l-food.cc
@@ -182,5 +182,5 @@ static const struct luaL_reg food_lib[] =
 
 void cluaopen_food(lua_State *ls)
 {
-    luaL_openlib(ls, "food", food_lib, 0);
+    luaL_register(ls, "food", food_lib);
 }

--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -1683,5 +1683,5 @@ void cluaopen_item(lua_State *ls)
     // Pop the metatable off the stack.
     lua_pop(ls, 1);
 
-    luaL_openlib(ls, "items", item_lib, 0);
+    luaL_register(ls, "items", item_lib);
 }

--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -639,5 +639,5 @@ void cluaopen_moninf(lua_State *ls)
 {
     clua_register_metatable(ls, MONINF_METATABLE, moninf_lib,
                             lua_object_gc<monster_info>);
-    luaL_openlib(ls, "monster", mon_lib, 0);
+    luaL_register(ls, "monster", mon_lib);
 }

--- a/crawl-ref/source/l-spells.cc
+++ b/crawl-ref/source/l-spells.cc
@@ -291,5 +291,5 @@ static const struct luaL_reg spells_clib[] =
 
 void cluaopen_spells(lua_State *ls)
 {
-    luaL_openlib(ls, "spells", spells_clib, 0);
+    luaL_register(ls, "spells", spells_clib);
 }

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -126,5 +126,5 @@ static const struct luaL_reg travel_lib[] =
 
 void cluaopen_travel(lua_State *ls)
 {
-    luaL_openlib(ls, "travel", travel_lib, 0);
+    luaL_register(ls, "travel", travel_lib);
 }

--- a/crawl-ref/source/l-view.cc
+++ b/crawl-ref/source/l-view.cc
@@ -223,5 +223,5 @@ static const struct luaL_reg view_lib[] =
 
 void cluaopen_view(lua_State *ls)
 {
-    luaL_openlib(ls, "view", view_lib, 0);
+    luaL_register(ls, "view", view_lib);
 }

--- a/crawl-ref/source/l-wiz.cc
+++ b/crawl-ref/source/l-wiz.cc
@@ -48,7 +48,7 @@ static const struct luaL_reg wiz_dlib[] =
 
 void dluaopen_wiz(lua_State *ls)
 {
-    luaL_openlib(ls, "wiz", wiz_dlib, 0);
+    luaL_register(ls, "wiz", wiz_dlib);
 }
 
 #endif

--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -1298,7 +1298,7 @@ static const struct luaL_reg you_clib[] =
 
 void cluaopen_you(lua_State *ls)
 {
-    luaL_openlib(ls, "you", you_clib, 0);
+    luaL_register(ls, "you", you_clib);
 }
 
 //
@@ -1604,5 +1604,5 @@ static const struct luaL_reg you_dlib[] =
 
 void dluaopen_you(lua_State *ls)
 {
-    luaL_openlib(ls, "you", you_dlib, 0);
+    luaL_register(ls, "you", you_dlib);
 }

--- a/crawl-ref/source/rltiles/tool/tile.cc
+++ b/crawl-ref/source/rltiles/tool/tile.cc
@@ -293,7 +293,9 @@ void tile::copy(const tile &img)
     m_filename = img.m_filename;
     m_pixels   = new tile_colour[m_width * m_height];
     m_shrink   = img.m_shrink;
-    memcpy(m_pixels, img.m_pixels, m_width * m_height * sizeof(tile_colour));
+    for (int i = 0, iend = m_width * m_height; i < iend; ++i) {
+        m_pixels[i] = img.m_pixels[i];
+    }
 
     // enum explicitly not copied
     m_enumname.clear();

--- a/crawl-ref/source/rltiles/tool/tile_colour.cc
+++ b/crawl-ref/source/rltiles/tool/tile_colour.cc
@@ -23,16 +23,6 @@ bool tile_colour::operator!=(const tile_colour &rhs) const
     return r != rhs.r || g != rhs.g || b != rhs.b || a != rhs.a;
 }
 
-const tile_colour &tile_colour::operator=(const tile_colour &rhs)
-{
-    r = rhs.r;
-    g = rhs.g;
-    b = rhs.b;
-    a = rhs.a;
-
-    return *this;
-}
-
 unsigned char &tile_colour::operator[](int idx)
 {
     assert(idx >= 0 && idx <= 4);

--- a/crawl-ref/source/rltiles/tool/tile_colour.h
+++ b/crawl-ref/source/rltiles/tool/tile_colour.h
@@ -34,7 +34,7 @@ public:
 
     bool operator==(const tile_colour &rhs) const;
     bool operator!=(const tile_colour &rhs) const;
-    const tile_colour &operator=(const tile_colour &rhs);
+    tile_colour &operator=(const tile_colour &rhs) = default;
 
     unsigned char &operator[](int idx);
     unsigned char operator[](int idx) const;

--- a/crawl-ref/source/rltiles/tool/tile_colour.h
+++ b/crawl-ref/source/rltiles/tool/tile_colour.h
@@ -28,7 +28,7 @@ enum COLORS
 class tile_colour
 {
 public:
-    tile_colour() {};
+    tile_colour() : r(0), g(0), b(0), a(0) {};
     tile_colour(unsigned char _r, unsigned char _g, unsigned char _b,
         unsigned char _a) : r(_r), g(_g), b(_b), a(_a) {}
 

--- a/crawl-ref/source/rltiles/tool/tile_page.cc
+++ b/crawl-ref/source/rltiles/tool/tile_page.cc
@@ -137,7 +137,6 @@ bool tile_page::write_image(const char *filename)
     }
 
     tile_colour *pixels = new tile_colour[m_width * m_height];
-    memset(pixels, 0, m_width * m_height * sizeof(tile_colour));
 
     for (unsigned int i = 0; i < m_tiles.size(); i++)
     {

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -2275,6 +2275,7 @@ void tag_read_char(reader &th, uint8_t format, uint8_t major, uint8_t minor)
         you.explore = unmarshallBoolean(th);
 }
 
+#if 0
 static void _cap_mutation_at(mutation_type mut, int cap)
 {
     if (you.mutation[mut] > cap)
@@ -2288,6 +2289,7 @@ static void _cap_mutation_at(mutation_type mut, int cap)
     if (you.innate_mutation[mut] > cap)
         you.innate_mutation[mut] = cap;
 }
+#endif
 
 static void tag_read_you(reader &th)
 {

--- a/crawl-ref/source/ui.h
+++ b/crawl-ref/source/ui.h
@@ -27,7 +27,7 @@ namespace ui {
 template <size_t N>
 struct vec {
     int items[N];
-    template <typename... Ts> vec<N> (Ts... l) : items{l...} {}
+    template <typename... Ts> vec(Ts... l) : items{l...} {}
     const int& operator[](int index) const { return items[index]; }
     int& operator[](int index) { return items[index]; }
     inline bool operator==(const vec<N>& rhs) {


### PR DESCRIPTION
These are a small pile of mostly trivial fixes I had to make in order to build Stoat Soup on an up-to-date, mostly-stable amd64 Gentoo install.

The update from luaL_openlib() to luaL_register() is to stop using a long-deprecated API that is removed in Lua 5.1.5 and perhaps prior versions.  Stoat Soup fails to build for me without this commit applied.

The other commits are to silence warnings that often point to invalid or deprecated C++ constructs.  There are eight of these commits because I've broken them out to make them easier to verify as being correct.

With all of these commits applied, Stoat Soup builds for me with no warnings.

No AI was used for any of these commits.